### PR TITLE
Pin `pydicom` version 2.4.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     gias3.learning
     gias3.registration
     numpy
-    pydicom
+    pydicom==2.4.4
     scikit-image
     scikit-learn
     scipy

--- a/src/gias3/image_analysis/__init__.py
+++ b/src/gias3/image_analysis/__init__.py
@@ -17,5 +17,5 @@ This file is part of GIAS. (https://bitbucket.org/jangle/gias)
     You should have received a copy of the GNU General Public License
     along with GIAS.  If not, see <http://www.gnu.org/licenses/>..
 """
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 


### PR DESCRIPTION
The current implementation is not compatible with the latest releases of `pydicom`. I am pinning version 2.4.4 until we have the chance to give this package a more thorough update.